### PR TITLE
Change the deserialization to throw TypeLoadException when type is unkonwn

### DIFF
--- a/JsonEnvelopes.Tests/EnvelopeJsonConverterTests.cs
+++ b/JsonEnvelopes.Tests/EnvelopeJsonConverterTests.cs
@@ -49,5 +49,21 @@ namespace JsonEnvelopes.Tests
             Assert.Contains($"\"{contentTypePropertyName}\":", json, StringComparison.Ordinal);
             Assert.Contains($"\"{contentPropertyName}\":", json, StringComparison.Ordinal);
         }
+
+        [Fact]
+        public void Deserialization_Throws_TypeLoadException_When_UnknownType()
+        {
+            var foo = new FooCommand<BarEntity>();
+            var envelope = new Envelope<FooCommand<BarEntity>>(foo);
+
+            var resultJson = JsonSerializer.Serialize<Envelope>(envelope);
+            resultJson = resultJson.Replace("JsonEnvelopes.Tests.FooCommand", "NewNamespace.FooCommand");
+
+            Assert.Throws<TypeLoadException>(() =>
+            {
+                var resultFoo = JsonSerializer.Deserialize<Envelope>(resultJson)
+                    .GetContent() as FooCommand<BarEntity>;
+            });
+        }
     }
 }

--- a/JsonEnvelopes/EnvelopeJsonConverter.cs
+++ b/JsonEnvelopes/EnvelopeJsonConverter.cs
@@ -25,7 +25,7 @@ namespace JsonEnvelopes
                         propertyName = reader.GetString();
                         break;
                     case JsonTokenType.String:
-                        if (contentTypePropertyName.Equals(propertyName, propertyNameComparison)) { contentType = Type.GetType(JsonSerializer.Deserialize<string>(ref reader, options)); }
+                        if (contentTypePropertyName.Equals(propertyName, propertyNameComparison)) { contentType = Type.GetType(JsonSerializer.Deserialize<string>(ref reader, options), true); }
                         break;
                     case JsonTokenType.StartObject:
                         if (contentPropertyName.Equals(propertyName, propertyNameComparison)) { content = JsonSerializer.Deserialize(ref reader, contentType, options); }


### PR DESCRIPTION
Change the deserialization to throw TypeLoadException when the envelop content type is unknown.

This scenario may happen when you send the envelope over the wire to another process, but that process does not have a declaration for the envelope content.

Before it was throwing ArgumentNullException, but now it's clearer what is causing the exception.
The TypeLoadException contains a nice message explaining what is the root cause for the exception.